### PR TITLE
feat(companies): add Vasion

### DIFF
--- a/content/companies/_index.md
+++ b/content/companies/_index.md
@@ -136,6 +136,14 @@ layout = "single"
       <td>Lehi</td>
     </tr>
     <tr>
+      <td><a href="https://www.vasion.com/" target="_blank" rel="nofollow">Vasion</a></td>
+      <td align="center">
+        <a href="https://github.com/PrinterLogic?tab=repositories&amp;language=go"><i class="fab fa-github"></i></a>
+        <a href="https://www.linkedin.com/company/vasion-software"><i class="fab fa-linkedin"></i></a>
+      </td>
+      <td>St. George/Lehi</td>
+    </tr>
+    <tr>
       <td><a href="https://www.vivint.com/" target="_blank" rel="nofollow">Vivint</a></td>
       <td align="center">
         <a href="https://github.com/vivint?tab=repositories&amp;language=go"><i class="fab fa-github"></i></a>


### PR DESCRIPTION
This pull request adds a new company, Vasion, to the `content/companies/_index.md` file. The addition includes the company's name, website link, GitHub and LinkedIn profiles, and location information.

* [`content/companies/_index.md`](diffhunk://#diff-cfbd90fb7fddf172546a587d83225ad1675aec07d8c3006c3847bd1cbccbce48R138-R145): Added a new table row for Vasion with links to its [website](https://www.vasion.com/), [GitHub repositories](https://github.com/PrinterLogic?tab=repositories&language=go), and [LinkedIn profile](https://www.linkedin.com/company/vasion-software), as well as its location ("St. George/Lehi").